### PR TITLE
fix readme error in truncate usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ yarn add tailwindcss-truncate-multiline
           lines: {
               3: '3',
               5: '5',
-              8: '8'.
+              8: '8',
           }
       }
     


### PR DESCRIPTION
There was a typo in the readme for the proper usage of the multiline plugin